### PR TITLE
Fix Navigator.permissions on Safari IOS

### DIFF
--- a/app/js/Geolocation.js
+++ b/app/js/Geolocation.js
@@ -127,7 +127,13 @@ BDB.Geolocation = (function(){
 		checkPermission : function(){
 			if (navigator.permissions) {
 			  return navigator.permissions.query({'name': 'geolocation'});
+			}else{
+				let fallback = new Promise(function(resolve,reject){
+			  		reject(false);
+			  	});
+			  return fallback;
 			}
+
 		},
 		reverseGeocode : function(lat, lng, successCB, failCB) {
   			const latlng = {lat: parseFloat(lat), lng: parseFloat(lng)};


### PR DESCRIPTION
navigator.permissions is not supported by Mobile Safari, so I'm returning a fallback promise returning a reject and a false parameter. 