### PR TITLE
Bugfix/geolocation analytics

### DIFF
--- a/app/js/Geolocation.js
+++ b/app/js/Geolocation.js
@@ -34,7 +34,7 @@ BDB.Geolocation = (function(){
     // set default options to geolocate
     let defaults = {
       enableHighAccuracy: true,
-      timeout: 10000,
+      // timeout: 10000, //dont think we need that, since it doesnt block the UI like before
       maximumAge: 500
     };
 

--- a/app/js/Geolocation.js
+++ b/app/js/Geolocation.js
@@ -41,14 +41,14 @@ BDB.Geolocation = (function(){
     let settings = Object.assign({}, defaults, param);
 
     let result = {
-      status : false,
+      statusOk : false,
       center : false,
       response : {}
     }
 
     let Location = new Promise(function(resolve,reject){
       if (positionWatcher){
-        result.status = true;
+        result.statusOk = true;
         result.center = true;
         result.response = currentPosition;
         resolve(result);
@@ -57,7 +57,7 @@ BDB.Geolocation = (function(){
           clearGeoWatch();
           navigator.geolocation.getCurrentPosition(
             position => {
-              result.status = true;
+              result.statusOk = true;
               result.center = true;
               result.response = position.coords;
               persistLocation(result.response);
@@ -87,17 +87,17 @@ BDB.Geolocation = (function(){
     document.dispatchEvent(event);
   };
   let geoWatch = function(options){
-    positionWatcher = navigator.geolocation.watchPosition(function(position){
+    positionWatcher = navigator.geolocation.watchPosition(position => {
       let result = {
-        status: true,
+        statusOk: true,
         center: false,
         response : position.coords
       };
       persistLocation(position.coords);
       geolocateDone(result);
-    },function(error){
+    }, error => {
       let result = {
-        status: false,
+        statusOk: false,
         center: false,
         response : error
       };

--- a/app/js/Geolocation.js
+++ b/app/js/Geolocation.js
@@ -41,14 +41,14 @@ BDB.Geolocation = (function(){
     let settings = Object.assign({}, defaults, param);
 
     let result = {
-      statusOk : false,
+      success : false,
       center : false,
       response : {}
     }
 
     let Location = new Promise(function(resolve,reject){
       if (positionWatcher){
-        result.statusOk = true;
+        result.success = true;
         result.center = true;
         result.response = currentPosition;
         resolve(result);
@@ -57,7 +57,7 @@ BDB.Geolocation = (function(){
           clearGeoWatch();
           navigator.geolocation.getCurrentPosition(
             position => {
-              result.statusOk = true;
+              result.success = true;
               result.center = true;
               result.response = position.coords;
               persistLocation(result.response);
@@ -89,7 +89,7 @@ BDB.Geolocation = (function(){
   let geoWatch = function(options){
     positionWatcher = navigator.geolocation.watchPosition(position => {
       let result = {
-        statusOk: true,
+        success: true,
         center: false,
         response : position.coords
       };
@@ -97,7 +97,7 @@ BDB.Geolocation = (function(){
       geolocateDone(result);
     }, error => {
       let result = {
-        statusOk: false,
+        success: false,
         center: false,
         response : error
       };

--- a/app/js/Map.js
+++ b/app/js/Map.js
@@ -251,7 +251,7 @@ BDB.Map = (function () {
     BDB.Geolocation.getLocation();
 
     document.addEventListener('geolocation:done', function (result) {
-      if (result.detail.statusOk) {
+      if (result.detail.success) {
         if (!isGeolocated){
           isGeolocated = true;
           setUserMarkerIcon();

--- a/app/js/Map.js
+++ b/app/js/Map.js
@@ -251,7 +251,7 @@ BDB.Map = (function () {
     BDB.Geolocation.getLocation();
 
     document.addEventListener('geolocation:done', function (result) {
-      if (result.detail.status) {
+      if (result.detail.statusOk) {
         if (!isGeolocated){
           isGeolocated = true;
           setUserMarkerIcon();

--- a/app/js/app.js
+++ b/app/js/app.js
@@ -1653,7 +1653,7 @@ $(() => {
       let result = e.detail;
       $('#geolocationBtn').removeClass('loading');
 
-      if (result.statusOk) {
+      if (result.success) {
         if (result.center) {
           console.log('Geolocation init');
           ga('send', 'event', 'Geolocation', 'init', `${result.response.latitude},${result.response.longitude}`);

--- a/app/js/app.js
+++ b/app/js/app.js
@@ -1653,32 +1653,34 @@ $(() => {
       let result = e.detail;
       $('#geolocationBtn').removeClass('loading');
 
-      if (result.status && result.center){
-        ga('send', 'event', 'Geolocation', 'init', `${result.response.latitude},${result.response.longitude}`);
-        return false;
-      }
-
-      ga('send', 'event', 'Geolocation', result.response.message ? `fail - ${result.response.message}`: 'fail - no_message');
-
-      switch(result.response.code) {
-      case 1:
-        // PERMISSION_DENIED
-        if (_isFacebookBrowser) {
-          toastr['warning']('Seu navegador parece não suportar essa função, que pena.');
-        } else {
-          toastr['warning']('Seu GPS está desabilitado, ou seu navegador parece não suportar essa função.');
+      if (result.statusOk) {
+        if (result.center) {
+          console.log('Geolocation init');
+          ga('send', 'event', 'Geolocation', 'init', `${result.response.latitude},${result.response.longitude}`);
         }
-        break; 
-      case 2:
-        // POSITION_UNAVAILABLE
-        toastr['warning']('Não foi possível recuperar sua posição do GPS.');
-        break;
-      case 3:
-        // TIMEOUT
-        toastr['warning']('Não foi possível recuperar sua posição do GPS.');
-        break;
+      } else {
+        console.error('Geolocation failed', result.response.message);
+        ga('send', 'event', 'Geolocation', result.response.message ? `fail - ${result.response.message}`: 'fail - no_message');
+  
+        switch(result.response.code) {
+        case 1:
+          // PERMISSION_DENIED
+          if (_isFacebookBrowser) {
+            toastr['warning']('Seu navegador parece não suportar essa função, que pena.');
+          } else {
+            toastr['warning']('Seu GPS está desabilitado, ou seu navegador parece não suportar essa função.');
+          }
+          break; 
+        case 2:
+          // POSITION_UNAVAILABLE
+          toastr['warning']('Não foi possível recuperar sua posição do GPS.');
+          break;
+        case 3:
+          // TIMEOUT
+          toastr['warning']('Não foi possível recuperar sua posição do GPS.');
+          break;
+        }
       }
-      
     });
     
     $('#addPlace').on('click', queueUiCallback.bind(this, () => {


### PR DESCRIPTION
Refatorei o nome da flag de sucesso ali par ficar mais clara a semantica. Primeira vez que olhei pra esse codigo achei que "status" fosse o código de status que volta do geolocation, mas na real era um booleano.

Refatorei a lógica no geolocation:done, tirando aquele return pra priorizar uma programação mais estruturada que refletisse melhor na sua estrutura a sua lógica.

Adicionei mensagens no console pra cada evento do Analytics. Inicialmente tinha feito isso pra debuggar, mas to começando a achar que talvez seja uma boa prática ter sempre uma mensagem no console quando enviamos um evento pro Analytics, pra ter certeza que tá funcionando direitinho. sem precisar usar a extensão do Chrome que é excessivamente verbosa.
Problemas nos eventos no Analytics são bem chatos porque o Analytics tem um banco de dados imutável, então as estatísticas ficam zoadas "pra sempre". Eu mesmo já sofri com isso várias vezes ao longo do projeto com bugs introduzidos por mim mesmo.