### PR TITLE
Fit viewport to show nearest place when initializing geolocation

### DIFF
--- a/app/js/Map.js
+++ b/app/js/Map.js
@@ -250,13 +250,19 @@ BDB.Map = (function () {
   let geolocate = function (options = {}) {
     BDB.Geolocation.getLocation();
 
-    document.addEventListener('geolocation:done', function (result) {
+    $(document).one('geolocation:done', result => {
       if (result.detail.success) {
         if (!isGeolocated){
           isGeolocated = true;
           setUserMarkerIcon();
         }
-        updateUserPosition(result.detail.response, result.detail.center);  
+        
+        if (options.isInitializingGeolocation) {
+          result.detail.center = false;
+          BDB.Map.fitToNearestPlace();
+        }
+
+        updateUserPosition(result.detail.response, result.detail.center);
       }else{
         isGeolocated = false;
         setUserMarkerIcon();
@@ -360,7 +366,7 @@ BDB.Map = (function () {
         if (getLocation){
           BDB.Geolocation.checkPermission().then(permission => {
             if (permission.state === 'granted') {
-              geolocate();
+              geolocate({isInitializingGeolocation: true});
             }
           });
         }
@@ -586,7 +592,6 @@ BDB.Map = (function () {
       bounds.extend(convertToGmaps(BDB.Geolocation.getCurrentPosition()));  
 
       var nearest = this.getListOfPlaces('nearest', 1)[0];
-      console.log('nearest place:', nearest); 
       var nearestPos = { lat: parseFloat(nearest.lat), lng: parseFloat(nearest.lng) };
       bounds.extend(nearestPos);
 


### PR DESCRIPTION
Se o usuário já deu permissão pra localização dele antes, na próxima vez que ele inicializar o bike de boa nós posicionaremos o mapa pra mostrar a posição dele E sempre o pin mais próximo.
O comportamento do botão de geolocalização mesmo continua o mesmo: ele centraliza o mapa na posição atual do usuário, que me parece ser o mais intuitivo.

_Duvidinha: será que deveríamos testar se esse bicicletário está em um raio de distância "razoável" antes de fazer isso? 🤔
Pode ser que a experiência fique estranha pra alguém que mora num estado sem bicicletários, por exemplo, porque o mapa vai inicializar com um zoom super longe. Por outro lado, meu maior objetivo com essa feature era que, vendo os vídeos dos usuários, parece que eles ficam confusos quando abrem o bike de boa pela primeira vez e não tem nada perto deles. Eles ficam procurando bicicletários em volta da sua posição, tendo que fazer um monte de _pan_ e _zoom_ (principalmente se estiver no mobile) até descobrir que não tem nada perto deles._