### PR TITLE
Reviews of Guide texts. Some improvements on the help tooltips as well

### DIFF
--- a/app/js/app.js
+++ b/app/js/app.js
@@ -75,7 +75,7 @@ $(() => {
         const $tooltipEl = $(e.currentTarget);
         swal({
           customClass: 'tooltip-modal',
-          html: $tooltipEl.data('title'),
+          html: $tooltipEl.data('title'), 
           showConfirmButton: false,
           showCloseButton: true
         });
@@ -2612,6 +2612,9 @@ $(() => {
     // Bind trigger for history changes
     History.Adapter.bind(window, 'statechange', () => {
       const state = History.getState();
+      
+      // Always close any open dialog if a navigation is triggered 
+      swal.close();
 
       if (_isFeatherlightOpen) {
         const openLightbox = $.featherlight.current();

--- a/app/scss/main.scss
+++ b/app/scss/main.scss
@@ -205,8 +205,7 @@ body {
 }
 
 // Completely hide occasional scrollbars for smoother transitions
-body::-webkit-scrollbar,
-.modal-dialog::-webkit-scrollbar {
+body::-webkit-scrollbar {
     display: none;
 }
 
@@ -591,25 +590,27 @@ p {
   align-items: center;
   
   .media-link {
-    opacity: 0.7;
     border: 0;
     padding: 2%;
     width: 28%; 
     // flex: 1; 
 
-    backface-visibility: hidden;
+    // Desktop-only version
+    @media screen and (min-width: $MOBILE_MAX_WIDTH) {
+      filter: grayscale(100%);
+      opacity: 0.7;
+      backface-visibility: hidden;
 
-    filter: grayscale(100%);
-    
-    transition: all 0.2s ease-in-out;
+      transition: all 0.2s ease-in-out;
 
-    &:hover,
-    &:focus {
-      opacity: 1;
-      text-decoration: none;
-      border: 0;
-      transform: scale(1.1);
-      filter: none;
+      &:hover,
+      &:focus {
+        opacity: 1;
+        text-decoration: none;
+        border: 0;
+        transform: scale(1.1);
+        filter: none;
+      }
     }
 
   }
@@ -1419,7 +1420,6 @@ a.unstyled-link {
   margin: 0 auto;
   display: block;
   margin-bottom: 3em; 
-  width: 70%;
 }
 
 #aboutModal,
@@ -1466,11 +1466,6 @@ a.unstyled-link {
       height: 28px;
       vertical-align: bottom;
     }
-  }
-
-  p {
-    font-size: $leading;
-    line-height: 1.6em;
   }
 
   p.subtitle {
@@ -5071,6 +5066,14 @@ body.modal-open {
 }
 
 .tooltip-modal {
+  box-shadow: none !important;
+  background: $green !important; 
+
+  .swal2-content, 
+  a {
+    color: white !important;
+  }
+
   p {
     text-align: left;
     font-size: 14px;

--- a/app/scss/main.scss
+++ b/app/scss/main.scss
@@ -5070,7 +5070,8 @@ body.modal-open {
   background: $green !important; 
 
   .swal2-content, 
-  a {
+  .swal2-close,
+  a { 
     color: white !important;
   }
 

--- a/app/templates/guideModal.hbs
+++ b/app/templates/guideModal.hbs
@@ -30,13 +30,13 @@
 
                         <div>
                             <div class="center">
-                            <img class="guide-type-img" alt="" src="/img/icon_guide_uinvertido.svg"/>
+                                <img class="guide-type-img" alt="" src="/img/icon_guide_uinvertido.svg"/>
                             </div>
 
                             <div>
-                            <p>
-                                Em forma de U ou semi-círculo, normalmente é uma estrutura reforçada e bem fixada no chão. É frequentemente considerado o melhor tipo de bicicletário, oferece segurança e estabilidade e permite usar trava ulock.
-                            </p>
+                                <p>
+                                    Em forma de U ou semi-círculo, normalmente é uma estrutura reforçada e bem fixada no chão. É frequentemente considerado o melhor tipo de bicicletário, oferece segurança e estabilidade e permite usar trava ulock. 
+                                </p>
                             </div>
                         </div>
                         
@@ -76,9 +76,18 @@
                             </div>
 
                             <div>
-                            <p>
-                                Pode ter várias formas. Os mais comuns são pequenos triângulos ou semi-círculos. A qualidade da estrutura varia bastante. Alguns são frágeis e mal fixados no chão, outros são mais rígidos e confiáveis. Este tipo economiza espaço, mas nem sempre é o mais prático ou mais seguro.
-                            </p>
+                                <p>
+                                    Pode ter várias formas. Os mais comuns são pequenos triângulos ou semi-círculos. A qualidade da estrutura varia bastante. Alguns são frágeis e mal fixados no chão, outros são mais rígidos e confiáveis. 
+                                </p>
+                                    
+                                <p>
+                                    A menos que se use uma trava flexível, normalmente só dá pra prender a bicicleta pela roda. Alguns destes bicicletários
+                                    não oferecem boa estabilidade e podem danificar a roda, os raios ou o câmbio traseiro, o que lhes rendeu o apelido carinhoso de "entorta-roda" entre os ciclistas.
+                                </p>
+
+                                <p>
+                                    Este tipo economiza espaço, mas nem sempre é o mais prático ou mais seguro.
+                                </p>
                             </div>
                         </div>
 
@@ -110,20 +119,24 @@
 
                         <div>
                             <div class="center">
-                            <img class="guide-type-img" alt="" src="/img/icon_guide_trave.svg"/>
+                                <img class="guide-type-img" alt="" src="/img/icon_guide_trave.svg"/>
                             </div>
 
                             <div>
-                            <p>
-                                Normalmente um poste de luz ou placa de trânsito. Alguns problemas comuns são deixar uma folga e a trava correr no poste derrubando a bicicleta no chão. Cuidado também pra não prender em um poste baixo onde a bicicleta possa ser roubada passando por cima dele.
-                            </p>
+                                <p>
+                                    Normalmente um poste de luz ou placa de trânsito. 
+                                </p>
+                                    
+                                <p>
+                                    Alguns problemas comuns são deixar uma folga e a trava correr no poste derrubando a bicicleta no chão. Cuidado também pra não prender em um poste baixo onde a bicicleta possa ser roubada passando por cima dele.
+                                </p>
                             </div>
                         </div>
 
                         <button class="close-and-filter link-button" data-prop="structureType" data-value="trave">
                             Ver no mapa <span class="infobox--caret glyphicon glyphicon-chevron-right"></span>
                         </button>
-
+ 
                         <div class="guide-img-row">
                             <a href="#" data-featherlight="https://s3.amazonaws.com/bikedeboa/images/1155.jpeg">
                             <img alt="Donna Laura - Porto Alegre, RS." src="" data-src="https://s3.amazonaws.com/bikedeboa/images/1155.jpeg"/>
@@ -148,9 +161,17 @@
                             </div>
 
                             <div>
-                            <p>
-                                Normalmente lembra uma goleira com ganchos para pendurar a bicicleta, ou apenas gancho na parede. Este tipo economiza espaço, mas nem sempre é o mais prático ou mais seguro.
-                            </p>
+                                <p>
+                                    Também conhecido como "varal", normalmente lembra uma goleira com ganchos para pendurar a bicicleta. Às vezes se trata de simples ganchos na parede.
+                                </p>
+
+                                <p>
+                                    Cuidado que alguns destes só permitem prender a bicicleta pela roda, a menos que se use uma trava flexível. Às vezes dá pra prender o quadro da bicicleta próximo aos pilares.
+                                </p>
+                                    
+                                <p>
+                                    Este tipo economiza espaço, mas nem sempre é o mais prático ou mais seguro. Pessoas com um pouco de dificuldade motora, como pessoas de mais idade ou muito jovens, podem ter dificuldade de usá-lo.
+                                </p>
                             </div>
                         </div>
 
@@ -191,7 +212,11 @@
 
                             <div>
                             <p>
-                                Normalmente não é bicicletário, mas algo da rua que é usado pra isso. Há muitas variações, e alguns são rígidos e bem fixados, outros não. Apesar de não ser feito pra isso, às vezes é até mais seguro do que um bicicletário de roda por exemplo. 
+                                Normalmente não é bicicletário, mas um objeto da rua ("mobiliário urbano") que é usado com este fim.
+                            </p>
+                                
+                            <p>
+                                Há muitas variações: alguns são rígidos e bem fixados, já outros são bem menos confiáveis. Apesar de não ser feito pra isso, às vezes é até mais seguro do que um bicicletário de roda por exemplo. 
                             </p>
                             </div>
                         </div>
@@ -224,9 +249,13 @@
                             </div>
 
                             <div>
-                            <p>
-                                Alguns bicicletários são diferentões e não se encaixam em nenhuma categoria. Alguns nem foram feitos pra serem bicicletários de fato. Lembre de verificar a foto e as avaliações de outros usuários, e na hora dê uma boa olhada pra conferir a qualidade da estrutura e se está bem fixado.
-                            </p>
+                                <p>
+                                    Alguns bicicletários são diferentões e não se encaixam em nenhuma categoria. Alguns nem foram feitos pra serem bicicletários de fato, mas acabam sendo usados assim.
+                                </p>
+                                    
+                                <p>
+                                    Lembre de verificar as avaliações de outros usuários no <b>bike de boa</b> e a foto. Na hora dê uma boa olhada pra conferir a qualidade da estrutura usando os conhecimentos deste guia.
+                                </p>
                             </div>
                         </div>
 
@@ -257,7 +286,7 @@
                         <div class='medium-separator'>...</div>
 
                         <h2>
-                        Sobre
+                        Referências
                         </h2>
 
                         <p>

--- a/app/templates/placeDetailsContent.hbs
+++ b/app/templates/placeDetailsContent.hbs
@@ -142,7 +142,8 @@
                         <a id="deroda-type-help-tooltip" class="glyphicon glyphicon-question-sign help-tooltip-trigger" role="button" tabindex="0" data-html="true" data-toggle="tooltip" data-placement="auto" data-title="<h2>De Roda</h2>
                         <p>Pode ter várias formas. Os mais comuns são pequenos triângulos ou semi-círculos.</p>
                         <p>A qualidade da estrutura varia bastante. Alguns são frágeis e mal fixados no chão, outros são mais rígidos e confiáveis.</p>
-                        <p>A menos que se use uma trava flexível, normalmente só dá pra prender a bicicleta pela roda. Alguns destes bicicletários não oferecem boa estabilidade e podem danificar a roda, os raios ou o câmbio traseiro.</p>
+                        <p>A menos que se use uma trava flexível, normalmente só dá pra prender a bicicleta pela roda. Alguns destes bicicletários não oferecem boa estabilidade e podem danificar a roda, os raios ou o câmbio traseiro, o que
+                        lhes rendeu o apelido carinhoso de 'entorta-roda' entre os ciclistas.</p>
                         <p>Este tipo economiza espaço, mas nem sempre é o mais prático ou mais seguro.</p>
                         <p><a href='#' class='open-guide-btn external-link'>Guia de tipos de bicicletários</a></p>
                         "></a>
@@ -155,16 +156,13 @@
                         "></a> 
                         {{/ifCond}}
                         {{#ifCond structureTypeCode '===' 'suspenso'}}
-                        <a id="suspenso-type-help-tooltip" class="glyphicon glyphicon-question-sign help-tooltip-trigger" role="button" tabindex="0" data-html="true" data-toggle="tooltip" data-placement="auto" data-title="<h2>Suspenso</h2>
-                        <p>Normalmente lembra uma goleira com ganchos para pendurar a bicicleta, ou apenas gancho na parede.</p>
-                        <p>Cuidado que alguns deste tipo só permitem prender a bicicleta pela roda, a menos que se use uma trava flexível. Às vezes dá pra prender o quadro da bicicleta próximo aos pilares.</p>
-                        <p>Este tipo economiza espaço, mas nem sempre é o mais prático ou mais seguro.</p>
+                        <a id="suspenso-type-help-tooltip" class="glyphicon glyphicon-question-sign help-tooltip-trigger" role="button" tabindex="0" data-html="true" data-toggle="tooltip" data-placement="auto" data-title="<h2>Suspenso</h2> <p> Também conhecido como 'varal', normalmente lembra uma goleira com ganchos para pendurar a bicicleta. Às vezes se trata de simples ganchos na parede. </p> <p> Cuidado que alguns destes só permitem prender a bicicleta pela roda, a menos que se use uma trava flexível. Às vezes dá pra prender o quadro da bicicleta próximo aos pilares. </p> <p> Este tipo economiza espaço, mas nem sempre é o mais prático ou mais seguro. Pessoas com um pouco de dificuldade motora, como pessoas de mais idade ou muito jovens, podem ter dificuldade de usá-lo. </p>
                         <p><a href='#' class='open-guide-btn external-link'>Guia de tipos de bicicletários</a></p>
                         "></a>
                         {{/ifCond}}
                         {{#ifCond structureTypeCode '===' 'grade'}}
                         <a id="grade-type-help-tooltip" class="glyphicon glyphicon-question-sign help-tooltip-trigger" role="button" tabindex="0" data-html="true" data-toggle="tooltip" data-placement="auto" data-title="<h2>Grade</h2>
-                        <p>Normalmente não é bicicletário, mas algo da rua que é usado pra isso. Há muitas variações, e alguns são rígidos e bem fixados, outros não.</p>
+                        <p>Normalmente não é bicicletário, mas algo da rua que é usado pra isso. Há muitas variações: alguns são rígidos e bem fixados, já outros são bem menos confiáveis.</p>
                         <p>Apesar de não ser feito pra isso, às vezes é até mais seguro do que um bicicletário de roda, por exemplo. Dá pra prender a bicicleta de formas variadas, inclusive com U-lock, e normalmente oferece boa estabilidade.</p>
                         <p>Prefira sempre <b>prender pelo quadro da bicicleta<b>.</p>
                         <p><a href='#' class='open-guide-btn external-link'>Guia de tipos de bicicletários</a></p>
@@ -172,9 +170,10 @@
                         {{/ifCond}}
                         {{#ifCond structureTypeCode '===' 'other'}}
                         <a id="other-type-help-tooltip" class="glyphicon glyphicon-question-sign help-tooltip-trigger" role="button" tabindex="0" data-html="true" data-toggle="tooltip" data-placement="auto" data-title="<h2>Outro</h2>
-                        <p>Um bicicletário diferentão, ou nem é bicicletário de fato.</p>
+                        <p> Alguns bicicletários são diferentões e não se encaixam em nenhuma categoria. Alguns nem foram feitos pra serem bicicletários
+                        de fato, mas acabam sendo usados assim.</p> 
                         <p>Lembre de verificar a foto e as avaliações de outros usuários, e na hora olhe bem para conferir a qualidade da estrutura.</p>
-                        <p>Sempre prenda sua bicicleta pelo quadro e o mais próximo possível desse objeto.</p>
+                        <p>Sempre prenda sua bicicleta pelo quadro e o mais próximo possível desse objeto.</p> 
                         <p><a href='#' class='open-guide-btn external-link'>Guia de tipos de bicicletários</a></p>
                         "></a>
                         {{/ifCond}}  


### PR DESCRIPTION
- Revisão de alguns textos do Guia e das tooltips, de maneira que fiquem mais alinhados (mas não necessariamente idênticos). Antes a ideia era o Guia ter versoes mais simplificadas dos textos das tooltips, mas agora ele tem praticamente o mesmo tamanho. Isso porque o Guia tem sido BASTANTE acessado (as pessoas encontram ele bastante no Google), e achei que ele tava meio pobrinho e podia trazer mais das das dicas que criamos.
- Implementa uma solução simples pro problema do usuário que tenta fechar uma modal usando o "voltar" do navegador.
- Mudei a cor de fundo da janelinha pra ficar um verdão gostoso com fonte branca. Queria mudar a cor de fundo do "overlay" também, pra que ficasse uma modal "fullscreen", mas quando a gente passa pro swal2 uma classe pra ele botar na dialog ele não poe no nodo mais superior, e sim no filho, daí não consigo mudar a cor de fundo de fora.

![image](https://user-images.githubusercontent.com/467471/38156632-cffc0736-3455-11e8-81b5-f640faf73dea.png)
